### PR TITLE
Add spacing on subheadings

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -807,7 +807,7 @@ pre {
 
 .subheading {
   font-size: 27px;
-  line-height: 1.1;
+  line-height: 1.5;
   display: block;
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: 300;

--- a/index.html
+++ b/index.html
@@ -1,9 +1,13 @@
 ---
 layout: page
 title: Jent.ly
-subtitle: Seamlessly provides a highlighted summary of your web content
+subtitle:
 use-site-title: true
 ---
+
+<p align="center"; class="subheading">Seamlessly provides a highlighted summary of your web content</p>
+
+<br>
 
 <img src="img/screenshot.png"/>
 <div class="chromestore">


### PR DESCRIPTION
For some reason it doesn't call to the backend when I host locally. In the screen shot I'm just using cursor highlighting, but you can see that now the highlight of two lines don't overlap.

![image](https://user-images.githubusercontent.com/15824429/74863825-83952200-531c-11ea-8cc4-2a9181694482.png)

home page:
![image](https://user-images.githubusercontent.com/15824429/74863882-a1628700-531c-11ea-98d6-c56f8b2d9cd1.png)
